### PR TITLE
Update srosmd.rb

### DIFF
--- a/lib/oxidized/model/srosmd.rb
+++ b/lib/oxidized/model/srosmd.rb
@@ -26,7 +26,7 @@ class SROSMD < Oxidized::Model
     #
     # Strip uptime.
     #
-    cfg.sub! /^System Up Time.*\n/, ''
+    cfg.gsub! /^System Up Time.*\n/, ''
     comment cfg
   end
 


### PR DESCRIPTION
-# System Up Time (64-bit): 6 days, 02:50:03.42 (hr:min:sec)
+# System Up Time (64-bit): 6 days, 03:51:37.41 (hr:min:sec)

64Bit system uptime was added between 22.3. and 23.10 release.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
